### PR TITLE
Updated url. The prof user can now submit a prof profile using the URL

### DIFF
--- a/src/main/java/org/sysc4806g30/graduateadmissionsmanagementsystem/system/ProfProfileController.java
+++ b/src/main/java/org/sysc4806g30/graduateadmissionsmanagementsystem/system/ProfProfileController.java
@@ -13,7 +13,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 
 @Controller
-@RequestMapping("/prof")
+@RequestMapping("/professor")
 public class ProfProfileController {
     private final ProfProfileService profProfileService;
     private static final Logger logger = LoggerFactory.getLogger(ProfProfileController.class);


### PR DESCRIPTION
 http://localhost:8080/professor/{profUID}/profevent/{eventUID} currently a prof can have multiple prof profiles with the same profUID and eventUID, might have to look into that